### PR TITLE
Fixed docs, replaced update method with setOptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ const effect = VANTA.WAVES({
 })
 
 // Later, when you want to update an animation in progress
-effect.update({
+effect.setOptions({
   color: 0xff88cc
 })
 ```


### PR DESCRIPTION
Hello! Please check this. `update()` method doesn't exist there, but `setOptions()` does the job.