### PR TITLE
Fix variable used for ref attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ class MyComponent extends React.Component {
     if (this.vantaEffect) this.vantaEffect.destroy()
   }
   render() {
-    return <div ref={this.myRef}>
+    return <div ref={this.vantaRef}>
       Foreground content goes here
     </div>
   }


### PR DESCRIPTION
In the code demonstrating usage with react, the div's ref attribute is set to `this.myRef` instead of `this.vantaRef`