### PR TITLE
Fixing the Fog effect on Retina screens

### DIFF
--- a/src/vanta.fog.js
+++ b/src/vanta.fog.js
@@ -32,8 +32,8 @@ uniform float zoom;
 
 float random (in vec2 _st) {
   return fract(sin(dot(_st.xy,
-                        vec2(12.9898,78.233)))*
-      43758.5453123);
+                     vec2(0.129898,0.78233)))*
+        437.585453123);
 }
 
 // Based on Morgan McGuire @morgan3d


### PR DESCRIPTION
Hi @tengbao, thank you for your work on this project!

This change should standardize the Fog effect across all devices and screens, since it appears that Retina screens can't render this effect properly at the moment.

Should close #67 
Should close #60 