### PR TITLE
Switch React docs to hooks-first

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,9 +80,36 @@ const effect = VANTA.WAVES('#my-background')
 effect.destroy() // e.g. call this in React's componentWillUnmount
 ```
 
-## Usage with React:
+## Usage with React (hooks):
 
 `npm i vanta`, then import a specific effect as follows. Make sure `three.js` or `p5.js` has already been included via &lt;script> tag.
+
+```js
+import React, { useState, useEffect, useRef } from 'react'
+import BIRDS from 'vanta/dist/vanta.birds.min'
+// Make sure window.THREE is defined, e.g. by including three.min.js in the document head using a <script> tag
+
+const MyComponent = (props) => {
+  const [vantaEffect, setVantaEffect] = useState(0)
+  const vantaRef = useRef(null)
+  useEffect(() => {
+    if (!vantaEffect) {
+      setVantaEffect(BIRDS({
+        el: vantaRef.current
+      }))
+    }
+    return () => {
+      if (vantaEffect) vantaEffect.destroy()
+    }
+  }, [vantaEffect])
+  return <div ref={vantaRef}>
+    Foreground content goes here
+  </div>
+}
+```
+[View fiddle &rarr;](https://jsfiddle.net/karlhorky/ko25ghbs/6/)
+
+## Usage with React class components:
 
 ```js
 import React from 'react'
@@ -110,32 +137,6 @@ class MyComponent extends React.Component {
 }
 ```
 [View fiddle &rarr;](https://jsfiddle.net/tsrwxzyL/2/)
-
-## Usage with React Hooks (requires React 16.8):
-
-```js
-import React, { useState, useEffect, useRef } from 'react'
-import BIRDS from 'vanta/dist/vanta.birds.min'
-// Make sure window.THREE is defined, e.g. by including three.min.js in the document head using a <script> tag
-
-const MyComponent = (props) => {
-  const [vantaEffect, setVantaEffect] = useState(0)
-  const myRef = useRef(null)
-  useEffect(() => {
-    if (!vantaEffect) {
-      setVantaEffect(BIRDS({
-        el: myRef.current
-      }))
-    }
-    return () => {
-      if (vantaEffect) vantaEffect.destroy()
-    }
-  }, [vantaEffect])
-  return <div ref={myRef}>
-    Foreground content goes here
-  </div>
-}
-```
 
 ## Usage with Vue 2 (SFC):
 


### PR DESCRIPTION
Hi there, thanks for Vanta! Looks really cool :)

Since the new version of the React docs is also now hooks-first (see https://beta.reactjs.org/), I wanted to open a PR to switch the React docs here to also be hooks first, and also included a new example on JSFiddle.