### PR TITLE
devicePixelRatio

### DIFF
--- a/src/_base.js
+++ b/src/_base.js
@@ -58,6 +58,7 @@ VANTA.VantaBase = class VantaBase {
       minWidth: 200,
       scale: 1,
       scaleMobile: 1,
+      devicePixelRatio: window.devicePixelRatio
     }, defaultOptions)
 
     if (userOptions instanceof HTMLElement || typeof userOptions === 'string') {
@@ -294,7 +295,7 @@ VANTA.VantaBase = class VantaBase {
     }
     if (this.renderer) {
       this.renderer.setSize(this.width, this.height)
-      this.renderer.setPixelRatio(window.devicePixelRatio / this.scale)
+      this.renderer.setPixelRatio(this.options.devicePixelRatio / this.scale)
     }
     typeof this.onResize === "function" ? this.onResize() : void 0
   }


### PR DESCRIPTION
Added option to set devicePixelRatio instead of use window value. When set to fixed value It helps to predict animation scaling when moving from display with devicePixelRatio 1 to 2 and more (retina)